### PR TITLE
Better descriptions

### DIFF
--- a/BridgeBidder/BidRule.cs
+++ b/BridgeBidder/BidRule.cs
@@ -56,6 +56,7 @@ namespace BridgeBidding
 
 		internal List<string> ConstraintDescriptions(PositionState ps)
 		{
+			HashSet<Type> didMultiDescribe = new HashSet<Type>();
 			var descriptions = new List<string>();
 			foreach (var constraint in _constraints)
 			{
@@ -64,6 +65,15 @@ namespace BridgeBidding
 					var d = describe.Describe(Call, ps);
 					if (d != null)
 						descriptions.Add(d);
+				}
+				else if (constraint is IDescribeMultipleConstraints describeMultiple)
+				{
+					if (!didMultiDescribe.Contains(constraint.GetType()))
+					{
+						didMultiDescribe.Add(constraint.GetType());
+						List<Constraint> sameConstraint = _constraints.FindAll(c => c.GetType() == constraint.GetType());
+						descriptions.AddRange(describeMultiple.Describe(Call, ps, sameConstraint));
+					}
 				}
 			}
 			return (descriptions.Count == 0) ? null : descriptions;

--- a/BridgeBidder/Bidder.cs
+++ b/BridgeBidder/Bidder.cs
@@ -108,7 +108,7 @@ namespace BridgeBidding
 
 		public static StaticConstraint Seat(params int[] seats)
 		{
-			return new StaticConstraint((call, ps) => seats.Contains(ps.Seat));
+			return new StaticConstraint((call, ps) => seats.Contains(ps.Seat), getDescription: (call, ps) => $"seat {ps.Seat}");
 		}
 		public static StaticConstraint LastBid(Call call)
 		{
@@ -138,12 +138,12 @@ namespace BridgeBidding
 		}
 
 		// Various vulnerability constraints.  Be careful with Not()
-		public static StaticConstraint IsVul = new StaticConstraint((call, ps) => ps.IsVulnerable);
-		public static StaticConstraint IsNotVul = new StaticConstraint((call, ps) => !ps.IsVulnerable);
-		public static StaticConstraint IsFavVul = new StaticConstraint((call, ps) => !ps.IsVulnerable && ps.RHO.IsVulnerable);
-		public static StaticConstraint IsUnfavVul = new StaticConstraint((call, ps) => ps.IsVulnerable && !ps.RHO.IsVulnerable);
-		public static StaticConstraint BothVul = new StaticConstraint((call, ps) => ps.IsVulnerable && ps.RHO.IsVulnerable);
-		public static StaticConstraint BothNotVul = new StaticConstraint((call, ps) => !ps.IsVulnerable && !ps.RHO.IsVulnerable);
+		public static StaticConstraint IsVul = new StaticConstraint((call, ps) => ps.IsVulnerable, description: "vul");
+		public static StaticConstraint IsNotVul = new StaticConstraint((call, ps) => !ps.IsVulnerable, description: "not vul");
+		public static StaticConstraint IsFavVul = new StaticConstraint((call, ps) => !ps.IsVulnerable && ps.RHO.IsVulnerable, description: "favorable vul");
+		public static StaticConstraint IsUnfavVul = new StaticConstraint((call, ps) => ps.IsVulnerable && !ps.RHO.IsVulnerable, description: "unfavorable vul");
+		public static StaticConstraint BothVul = new StaticConstraint((call, ps) => ps.IsVulnerable && ps.RHO.IsVulnerable, description: "all vul");
+		public static StaticConstraint BothNotVul = new StaticConstraint((call, ps) => !ps.IsVulnerable && !ps.RHO.IsVulnerable, description: "none vul");
 		
 		/*	-- TODO Figure out what we want to do about constraint groups.  Specifically static constraint groups.
 		public static StaticConstraint StaticAnd(params StaticConstraint[] constraints)
@@ -157,13 +157,17 @@ namespace BridgeBidding
 			});
 		}
 		*/ 
-		public static StaticConstraint IsReverse = new StaticConstraint((call, ps) => ps.IsOpenerReverseBid(call));
+		public static StaticConstraint IsReverse = new StaticConstraint((call, ps) => ps.IsOpenerReverseBid(call), description: "reverse");
 		public static StaticConstraint ForcedToBid = new StaticConstraint((call, ps) => ps.ForcedToBid);
 
 
 		public static StaticConstraint Not(StaticConstraint c)
 		{
-			return new StaticConstraint((call, ps) => !c.Conforms(call, ps));
+			return new StaticConstraint(eval: (call, ps) => !c.Conforms(call, ps),
+										getDescription: (call, ps) => { 
+											var desc = c.Describe(call, ps);
+											return string.IsNullOrEmpty(desc) ? null : $"not {desc}";
+										});
 		}
 
 		public static StaticConstraint Partner(Constraint constraint)

--- a/BridgeBidder/CallGroup.cs
+++ b/BridgeBidder/CallGroup.cs
@@ -86,6 +86,11 @@ namespace BridgeBidding
                     Debug.Assert(BestCall == null || !call.Equals(BestCall.Call));
                     this.Remove(call);
                 }
+                else
+                {
+                    // Add any group annotations to every call
+                    this[call].Annotations.AddRange(this.Annotations);
+                }
             }
         }
 

--- a/BridgeBidder/Constraint.cs
+++ b/BridgeBidder/Constraint.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 
 namespace BridgeBidding
@@ -29,18 +32,28 @@ namespace BridgeBidding
         }
     }
 
-    public class StaticConstraint: Constraint
+    public class StaticConstraint: Constraint, IDescribeConstraint
     {
         Func<Call, PositionState, bool> _eval;
+        Func<Call, PositionState, string> _getDescription;
 
-        public StaticConstraint(Func<Call, PositionState, bool> eval = null)
+        public StaticConstraint(Func<Call, PositionState, bool> eval = null,
+                                Func<Call, PositionState, string> getDescription = null,
+                                string description = null)
         {
+            Debug.Assert(getDescription == null || description == null, "Cannot specify both getDescription and description");
             _eval = eval != null ? eval : (call, ps) => true;
+            _getDescription = getDescription != null ? getDescription : (call, ps) => description;
         }
-
+       
         public virtual bool Conforms(Call call, PositionState ps)
         {
             return _eval(call, ps);
+        }
+
+        public virtual string Describe(Call call, PositionState ps)
+        {
+            return _getDescription(call, ps);
         }
     }
 
@@ -55,10 +68,15 @@ namespace BridgeBidding
         void ShowState(Call call, PositionState ps, HandSummary.ShowState showHand, PairAgreements.ShowState showAgreements);
     }
 
-    // This is a place-holder for getting desc
+    
     public interface IDescribeConstraint
     {
         string Describe(Call call, PositionState ps);
+    }
+
+    public interface IDescribeMultipleConstraints
+    {
+        List<string> Describe(Call call, PositionState ps, List<Constraint> constraints);
     }
 
 }

--- a/BridgeBidder/Constraints/PairMinShape.cs
+++ b/BridgeBidder/Constraints/PairMinShape.cs
@@ -80,7 +80,7 @@ namespace BridgeBidding
         {
             if (GetSuit(_suit, call) is Suit suit)
             {
-                return $"{_min} {suit.ToSymbol()} held by partnership";
+                return $"{_min}+{suit.ToSymbol()} held by partnership";
             }
             return null;
         }

--- a/BridgeBidder/Constraints/PairMinShape.cs
+++ b/BridgeBidder/Constraints/PairMinShape.cs
@@ -80,7 +80,7 @@ namespace BridgeBidding
         {
             if (GetSuit(_suit, call) is Suit suit)
             {
-                return $"{_min}+{suit.ToSymbol()} held by partnership";
+                return $"{_min}+ {suit.ToSymbol()} held by partnership";
             }
             return null;
         }

--- a/BridgeBidder/Constraints/Points.cs
+++ b/BridgeBidder/Constraints/Points.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
-using System.Security.Cryptography.X509Certificates;
 
 namespace BridgeBidding
 {


### PR DESCRIPTION
IDescribeMultipleConstraints is implemented by ShowsPoints.

Also fixed a bug with group annotations (those that are not associated with a single call, but that apply to an entire call group) were never returned.  They are now added to every rule in a group.  You will see the Convention annotation appearing in many more calls now.  Annotations were there, but weren't being returned.