### PR TITLE
Sort description parts

### DIFF
--- a/BridgeBidder/BidRule.cs
+++ b/BridgeBidder/BidRule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace BridgeBidding
 {
@@ -58,7 +59,7 @@ namespace BridgeBidding
 		{
 			HashSet<Type> didMultiDescribe = new HashSet<Type>();
 			var descriptions = new List<string>();
-			foreach (var constraint in _constraints)
+			foreach (var constraint in _constraints.OrderBy(ConstraintSort.ForDescription))
 			{
 				if (constraint is IDescribeConstraint describe)
 				{

--- a/BridgeBidder/ConstraintSort.cs
+++ b/BridgeBidder/ConstraintSort.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace BridgeBidding
+{
+	public static class ConstraintSort {
+        private static List<Type> DescriptionOrder = new List<Type>() {
+            typeof(ShowsPoints),
+            typeof(PairShowsPoints),
+            typeof(ShowsShape),
+            typeof(PairShowsMinShape)
+        };
+
+        public static int ForDescription(Constraint constraint) {
+            var index = DescriptionOrder.IndexOf(constraint.GetType());
+            return index == -1 ? DescriptionOrder.Count : index;
+        }
+    }
+}


### PR DESCRIPTION
Always puts points first, followed by shape. Other constraints are left in the order passed to their CallFeature.