### PR TITLE
Lower Shape limit to 10 for descriptions

### DIFF
--- a/BridgeBidder/Constraints/Losers.cs
+++ b/BridgeBidder/Constraints/Losers.cs
@@ -82,7 +82,7 @@ namespace BridgeBidding
         
         string IDescribeConstraint.Describe(Call call, PositionState ps)
         {
-            var range = Range.GetString(_min, _max, 13);
+            var range = Range.GetString(_min, _max, 10);
             var s = _min == 1 && _min == _max ? "" : "s";
             if (_handLosers) {
                 return $"{range} loser{s} in hand";

--- a/BridgeBidder/Constraints/Shape.cs
+++ b/BridgeBidder/Constraints/Shape.cs
@@ -47,7 +47,7 @@ namespace BridgeBidding
         {
             if (GetSuit(_suit, call) is Suit suit)
             {
-                return $"{Range.GetString(_min, _max, 13)} {suit.ToSymbol()}";
+                return $"{Range.GetString(_min, _max, 10)} {suit.ToSymbol()}";
             }
             return null;
         }


### PR DESCRIPTION
Display more bids as "5+" instead of "5-10", etc. This appears to be more in line with typical explanations even if the latter is more technically correct.